### PR TITLE
chore: add GitHub Actions CI and Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 10

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,29 @@
+name: CI
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - run: npm ci
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Test
+        run: npm test
+
+      - name: Audit (prod deps, high+)
+        run: npm audit --omit=dev --audit-level=high
+        continue-on-error: true


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/ci.yml` — runs on every push to master and on all PRs:
  - **Lint** (`npm run lint`) — blocking
  - **Test** (`npm test`, Vitest) — blocking
  - **Audit** (`npm audit --omit=dev --audit-level=high`) — non-blocking (`continue-on-error`), reports high-severity production vulnerabilities without failing the build
- Adds `.github/dependabot.yml` — weekly npm dependency PRs, up to 10 open at a time

## Test plan

- [ ] Open a PR and confirm the CI workflow appears and passes
- [ ] Confirm Dependabot PRs start appearing on schedule