### PR TITLE
refactor: remove dead stubs (db.js, middleware, toRes)

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -2,8 +2,6 @@ import express from 'express'
 import cors from 'cors'
 import morgan from 'morgan'
 import bodyParser from 'body-parser'
-import initializeDb from './db.js'
-import middleware from './middleware/index.js'
 import mocker from './api/mocker.js'
 import twilio from './api/twilio.js'
 import version from './api/version.js'
@@ -19,11 +17,8 @@ app.use(cors({ exposedHeaders: config.corsHeaders }))
 app.use(bodyParser.json({ limit: config.bodyLimit }))
 app.use(bodyParser.urlencoded({ extended: true }))
 
-initializeDb(db => {
-    app.use(middleware({ config, db }))
-    app.use('/version', version({ config, db }))
-    app.use('/mock', mocker({ config, db }))
-    app.use('/twilio', twilio({ config, db }))
-})
+app.use('/version', version())
+app.use('/mock', mocker())
+app.use('/twilio', twilio())
 
 export default app

--- a/src/db.js
+++ b/src/db.js
@@ -1,4 +1,0 @@
-export default callback => {
-    // connect to a database if needed, then pass it to `callback`:
-    callback()
-}

--- a/src/lib/util.js
+++ b/src/lib/util.js
@@ -1,27 +1,6 @@
-/**	Creates a callback that proxies node callback style arguments to an Express Response object.
- *	@param {express.Response} res	Express HTTP Response
- *	@param {number} [status=200]	Status code to send on success
- *
- *	@example
- *		list(req, res) {
- *			collection.find({}, toRes(res))
- *		}
- */
-export function toRes(res, status=200) {
-	return (err, thing) => {
-		if (err) return res.status(500).send(err)
-
-		if (thing && typeof thing.toObject==='function') {
-			thing = thing.toObject()
-		}
-		res.status(status).json(thing)
-	}
-}
-
 export function isValidISODate(value) {
-  const date = new Date(value)
-  if (!date.getTime()) return false
-  /* truncate to whatever decimal the value use */
-  const iso = date.toISOString().substring(0, value.length - 1) + "Z"
-  return iso === value
+    const date = new Date(value)
+    if (!date.getTime()) return false
+    const iso = date.toISOString().substring(0, value.length - 1) + 'Z'
+    return iso === value
 }

--- a/src/middleware/index.js
+++ b/src/middleware/index.js
@@ -1,9 +1,0 @@
-import { Router } from 'express'
-
-export default () => {
-    let routes = Router()
-
-    // add middleware here
-
-    return routes
-}


### PR DESCRIPTION
## Summary

Removes three layers of indirection that never did anything:

- **`src/db.js`** — callback stub that immediately calls its argument; deleted, `app.js` now registers routes directly
- **`src/middleware/index.js`** — returns an empty `Router()` with no middleware attached; deleted, `app.use(middleware(...))` call removed
- **`toRes()` in `src/lib/util.js`** — Mongoose-style callback adapter, never called anywhere in this codebase; `isValidISODate` kept

The three router factories (`mocker`, `twilio`, `version`) already had the signature `() => {}` — they never consumed the `{ config, db }` params threaded through them — so no callers needed updating.

## Test plan

- [x] `npm test` — 27/27 tests pass
- [x] `npm run lint` — no issues