### PR TITLE
fix: delete orphaned src/config.json

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -1,5 +1,0 @@
-{
-	"port": 1090,
-	"bodyLimit": "100kb",
-	"corsHeaders": ["Link"]
-}


### PR DESCRIPTION
## Summary

`src/config.json` was left behind when `src/config.js` replaced it in R1 (drop Babel). Nothing imports it — this removes the duplicate.

## Test plan

- [x] `npm test` — 27/27 tests pass
- [x] `npm run lint` — no issues