### PR TITLE
fix: add sha fallback tag to prevent docker push failure on workflow_dispatch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,6 +63,7 @@ jobs:
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{major}}
+            type=sha
 
       # Build locally first so Wiz can scan before anything is pushed.
       - name: Build image for scanning


### PR DESCRIPTION
## Summary

- `docker/metadata-action` only generates tags for `type=semver` patterns, which require a git tag context
- When the release workflow is triggered via `workflow_dispatch` with `dry_run: false`, no semver tag exists, so `steps.meta.outputs.tags` is empty
- `docker/build-push-action` with `push: true` and no tags fails with: `tag is needed when pushing to registry`
- Adding `type=sha` ensures there is always at least one tag, preventing the error

## Test plan

- [ ] Trigger the release workflow via `workflow_dispatch` with `dry_run: false` — should no longer fail at the "Build and push" step
- [ ] Trigger the release workflow via a `v*` tag push — semver tags should still be generated and used as before